### PR TITLE
Fixed building for linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "run-os",
     "build:win32": "electron-builder --win",
     "build:darwin": "electron-builder --mac",
+    "build:linux": "electron-builder --linux",
     "clean": "rimraf ./dist",
     "release": "electron-builder --publish always"
   },
@@ -61,6 +62,11 @@
         }
       ],
       "icon": "assets/icons/win/icon.ico"
+    },
+    "linux": {
+      "category": "public.build.automation",
+      "icon": "assets/icons/png/256x256.png",
+      "target": "AppImage"
     },
     "nsis": {
       "runAfterFinish": true,


### PR DESCRIPTION
I tried to build this on Ubuntu 20.04 and got this error:

```
$ npm run build

> OBSN.Electron.Capture.App@1.0.5 build /home/freddeliv/privat/obs-plugins/electroncapture
> run-os

npm ERR! missing script: build:linux
npm ERR! 
npm ERR! Did you mean this?
npm ERR!     build:win32

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/XXXXX/.npm/_logs/2020-08-18T08_59_47_518Z-debug.log
```

So I added this to be able to run `npm run build` on linux.

I'm not a node developer so I'm sorry if this is wrong. But it works for me to build with this.