### PR TITLE
Add option to toggle always on top

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "afterSign": "./afterSign.js"
   },
   "devDependencies": {
-    "electron": "^9.3.0",
+    "electron": "^10.1.1",
     "electron-builder": "^22.8.0",
     "electron-notarize": "^1.0.0",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
- Toggle via context menu
- Toggle via -pin or -p if launched via cli
- Move resize options to a submenu to reduce clutter

Default behavior is:

- Mac: Always on top is default
- Every other os: Always on top comes disabled by default