### PR TITLE
forced 16/9 window aspect ratio option

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const electron = require('electron')
 const process = require('process')
 
 process.on('uncaughtException', function (error) {
-    error.log(error);
+    console.error(error);
 });
 
 const {app, BrowserWindow, ipcMain, screen, shell, globalShortcut , session, desktopCapturer} = require('electron')
@@ -60,6 +60,7 @@ if (!(url.startsWith("http"))){
 }
 
 var counter=0;
+var forcingAspectRatio = false;
 
 function createWindow (URL=url) {
  
@@ -284,6 +285,22 @@ contextMenu({
 						browserWindow.setVisibleOnAllWorkspaces(true);
 					}
 
+				}
+			},
+			{
+				label: 'Force 16/9 aspect ratio',
+				type: 'checkbox',
+				visible: true,
+				checked: forcingAspectRatio,
+				click: () => {
+					if (forcingAspectRatio) {
+						browserWindow.setAspectRatio(0)
+						forcingAspectRatio = false
+					} else {
+						browserWindow.setAspectRatio(16/9)
+						forcingAspectRatio = true
+					}
+					
 				}
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "afterSign": "./afterSign.js"
   },
   "devDependencies": {
-    "electron": "^12.0.0-beta.1",
+    "electron": "^12.0.0",
     "electron-builder": "^22.9.1",
     "electron-notarize": "^1.0.0",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
- WARNING: Updates to electron 12 
- Adds a "force 16/9 aspect ratio" option to the context menu. Should properly keep track of state as well.