### PR TITLE
Action: release on v.x.x tag

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -2,7 +2,9 @@ name: Build/release
 
 on:
   push:
-
+    branches:
+      - master
+      
 jobs:
   release:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,32 @@
+name: Build/release
+
+on:
+  push:
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          
+      - name: Electron Builder Action
+        uses: samuelmeuli/action-electron-builder@v1.6.0
+        with:
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+
+          # If the commit is tagged with a version (e.g. "v1.0.0"),
+          # release the app after building
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
This github action should:

- Provide CI status on the repo by trying to build the windows / macOS apps every time code is pushed.
- Release binaries to a github release when a new tag is pushed as a release. Eg: `v2.0.0`