### PR TITLE
Do not use sudo for npm commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ To get the actual app source code and to build a distributable version, see belo
 ```
 git clone https://github.com/steveseguin/electroncapture
 cd electroncapture
-sudo npm install
-sudo npm run build:linux
+npm install
+npm run build:linux
 ```
 The file you need to run will be in the dist folder.
 


### PR DESCRIPTION
Firstly, it's a security hazard to install local node modules with elevated security privileges.
Secondly, the commands work perfectly fine without sudo.