### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Lastly, since playback is agnostic, you can window-capture the same video multip
 | --css     	| -css   	| Pass a CSS file to insert into newly created windows      	| test.css                             	|                                                          	|
 | --chroma     	| -color   	| Pass a 3 or 4 character HEX value to change the background color of websites      	| 0F0C                             	|                                                          	|
 
-* note: Use the --help command to get the most recent available commands and options.  While I try to keep the documenation update to date, I'm not always the best at it.
+* note: Use the --help command to get the most recent available commands and options.  While I try to keep the documentation update to date, I'm not always the best at it.
 
 The default frameless resolution of the capture window is 1280x720. The app automatically accounts for high-DPI displays, so it is always 1:1 pixel-accurate with the specified resolution on even Apple Retina displays.
 


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "documenation" to "documentation" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.